### PR TITLE
fix implicit fallthrough in some switch statements

### DIFF
--- a/src/core/memstore.c
+++ b/src/core/memstore.c
@@ -914,6 +914,7 @@ sdb_memstore_get_field(sdb_memstore_obj_t *obj, int field, sdb_data_t *res)
 				return -1;
 			tmp.type = SDB_TYPE_BOOLEAN;
 			tmp.data.boolean = METRIC(obj)->stores_num > 0;
+			break;
 		default:
 			return -1;
 	}

--- a/src/utils/ssl.c
+++ b/src/utils/ssl.c
@@ -159,6 +159,7 @@ ssl_log_err(int prio, SSL *ssl, int status, const char *prefix, ...)
 				sdb_log(prio, "%s: unexpected end-of-file", msg);
 			else if (! errno)
 				errno = EIO;
+			break;
 		case SSL_ERROR_SSL:
 			return ssl_log(prio, msg);
 		default:


### PR DESCRIPTION
When building on GCC-7, -Wimplicit-fallthrough throws up these two cases.

From what I can tell, breaking the switch is the correct behaviour in both of these cases.